### PR TITLE
Fix tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
         </dependency>
+		<dependency>
+			<groupId>com.c4-soft.springaddons</groupId>
+			<artifactId>spring-addons-oauth2-test</artifactId>
+			<version>6.0.7</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.3</version>
+        <version>3.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>dev.danvega</groupId>

--- a/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
+++ b/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
@@ -1,11 +1,7 @@
 package dev.danvega.jwt.config;
 
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
-import com.nimbusds.jose.jwk.source.JWKSource;
-import com.nimbusds.jose.proc.SecurityContext;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -27,67 +23,61 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    private final RsaKeyProperties jwtConfigProperties;
+	private final RsaKeyProperties jwtConfigProperties;
 
-    public SecurityConfig(RsaKeyProperties jwtConfigProperties) {
-        this.jwtConfigProperties = jwtConfigProperties;
-    }
+	public SecurityConfig(RsaKeyProperties jwtConfigProperties) {
+		this.jwtConfigProperties = jwtConfigProperties;
+	}
 
-    @Bean
-    public InMemoryUserDetailsManager users() {
-        return new InMemoryUserDetailsManager(
-                User.withUsername("dvega")
-                        .password("{noop}password")
-                        .authorities("read")
-                        .build()
-        );
-    }
+	@Bean
+	public InMemoryUserDetailsManager users() {
+		return new InMemoryUserDetailsManager(User.withUsername("dvega").password("{noop}password").authorities("read").build());
+	}
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http
-                .csrf(csrf -> csrf.disable())
-                .authorizeRequests( auth -> auth
-                        .mvcMatchers("/token").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .exceptionHandling((ex) -> ex
-                        .authenticationEntryPoint(new BearerTokenAuthenticationEntryPoint())
-                        .accessDeniedHandler(new BearerTokenAccessDeniedHandler())
-                )
-                .httpBasic(Customizer.withDefaults()) //
-                .build();
-    }
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http.csrf(csrf -> csrf.disable()).authorizeHttpRequests(auth -> auth.requestMatchers("/token").permitAll().anyRequest().authenticated())
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
+				.exceptionHandling(
+						(ex) -> ex.authenticationEntryPoint(new BearerTokenAuthenticationEntryPoint())
+								.accessDeniedHandler(new BearerTokenAccessDeniedHandler()))
+				.httpBasic(Customizer.withDefaults()) //
+				.build();
+	}
 
-    @Bean
-    JwtDecoder jwtDecoder() {
-        return NimbusJwtDecoder.withPublicKey(jwtConfigProperties.publicKey()).build();
-    }
+	@Bean
+	JwtDecoder jwtDecoder() {
+		return NimbusJwtDecoder.withPublicKey(jwtConfigProperties.publicKey()).build();
+	}
 
-    @Bean
-    JwtEncoder jwtEncoder() {
-        JWK jwk = new RSAKey.Builder(jwtConfigProperties.publicKey()).privateKey(jwtConfigProperties.privateKey()).build();
-        JWKSource<SecurityContext> jwks = new ImmutableJWKSet<>(new JWKSet(jwk));
-        return new NimbusJwtEncoder(jwks);
-    }
+	@Bean
+	JwtEncoder jwtEncoder() {
+		JWK jwk = new RSAKey.Builder(jwtConfigProperties.publicKey()).privateKey(jwtConfigProperties.privateKey()).build();
+		JWKSource<SecurityContext> jwks = new ImmutableJWKSet<>(new JWKSet(jwk));
+		return new NimbusJwtEncoder(jwks);
+	}
 
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("https://localhost:3000"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowedMethods(List.of("GET"));
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("https://localhost:3000"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowedMethods(List.of("GET"));
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
 }

--- a/src/main/java/dev/danvega/jwt/controller/HomeController.java
+++ b/src/main/java/dev/danvega/jwt/controller/HomeController.java
@@ -1,22 +1,22 @@
 package dev.danvega.jwt.controller;
 
+import java.security.Principal;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.security.Principal;
-
 @RestController
 public class HomeController {
 
-    @GetMapping
-    public String home(Principal principal) {
-        return "Hello, " + principal.getName();
-    }
+	@GetMapping("/")
+	public String home(Principal principal) {
+		return "Hello, " + principal.getName();
+	}
 
-    @PreAuthorize("hasAuthority('SCOPE_read')")
-    @GetMapping("/secure")
-    public String secure() {
-        return "This is secured!";
-    }
+	@PreAuthorize("hasAuthority('SCOPE_read')")
+	@GetMapping("/secure")
+	public String secure() {
+		return "This is secured!";
+	}
 }

--- a/src/test/java/dev/danvega/jwt/controller/HomeControllerTest.java
+++ b/src/test/java/dev/danvega/jwt/controller/HomeControllerTest.java
@@ -1,54 +1,60 @@
 package dev.danvega.jwt.controller;
 
-import dev.danvega.jwt.config.SecurityConfig;
-import dev.danvega.jwt.service.TokenService;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest({HomeController.class, AuthController.class})
-@Import({SecurityConfig.class, TokenService.class})
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithMockJwtAuth;
+
+import dev.danvega.jwt.config.SecurityConfig;
+import dev.danvega.jwt.service.TokenService;
+
+@WebMvcTest({ HomeController.class, AuthController.class })
+@Import({ SecurityConfig.class, TokenService.class })
 class HomeControllerTest {
 
-    @Autowired
-    MockMvc mvc;
+	@Autowired
+	MockMvc mvc;
 
-    @Test
-    void rootWhenUnauthenticatedThen401() throws Exception {
-        this.mvc.perform(get("/"))
-                .andExpect(status().isUnauthorized());
-    }
+	@Test
+	void rootWhenUnauthenticatedThen401() throws Exception {
+		this.mvc.perform(get("/")).andExpect(status().isUnauthorized());
+	}
 
-    @Test
-    void rootWhenAuthenticatedThenSaysHelloUser() throws Exception {
-        MvcResult result = this.mvc.perform(post("/token")
-                        .with(httpBasic("dvega", "password")))
-                .andExpect(status().isOk())
-                .andReturn();
+	@Test
+	void rootWhenAuthenticatedThenSaysHelloUser() throws Exception {
+		MvcResult result = this.mvc.perform(post("/token").with(httpBasic("dvega", "password"))).andExpect(status().isOk()).andReturn();
 
-        String token = result.getResponse().getContentAsString();
+		String token = result.getResponse().getContentAsString();
 
-        this.mvc.perform(get("/")
-                        .header("Authorization", "Bearer " + token))
-                .andExpect(content().string("Hello, dvega"));
-    }
+		this.mvc.perform(get("/").header("Authorization", "Bearer " + token)).andExpect(content().string("Hello, dvega"));
+	}
 
-    @Test
-    @WithMockUser
-    public void rootWithMockUserStatusIsOK() throws Exception {
-        this.mvc.perform(get("/")).andExpect(status().isOk());
-    }
+	@Test
+	@WithMockJwtAuth
+	public void rootWithMockUserStatusIsOK() throws Exception {
+		this.mvc.perform(get("/")).andExpect(status().isOk());
+	}
 
+	@Test
+	@WithMockJwtAuth("SCOPE_read")
+	public void securedWithReadStatusIsOK() throws Exception {
+		this.mvc.perform(get("/secure")).andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockJwtAuth
+	public void securedWithoutReadStatusIsForbidden() throws Exception {
+		this.mvc.perform(get("/secure")).andExpect(status().isForbidden());
+	}
 
 }


### PR DESCRIPTION
`@WithMockUser` populates test security-context with `UsernamePasswordAuthenticationToken` when your runtime security configuration sets security-context with `JwtAuthenticationToken` instances.

You should either use `org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt` MockMvc request post processor from `spring-security-test`:
```java
this.mvc.perform(get("/").with(jwt()))...
```

Or `@WithMockJwtAuth` from `spring-addons-oauth2-test`, like I do in this pull-request.

P.S.
I am the author of both solutions (look at the `@author` tag of `JwtRequestPostProcessor`), but have a preference for the annotations, which enable to test `@Controller`, but also other kind of `@Compenent` (`@Service`, `@Repository`, ...) secured with `@PreAuthorize` or `@PostFilter`