### PR TITLE
Changing method reference from requestMatcher to securityMatcher

### DIFF
--- a/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
+++ b/src/main/java/dev/danvega/jwt/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain tokenSecurityFilterChain(HttpSecurity http) throws Exception {
 		return http
-				.requestMatcher(new AntPathRequestMatcher("/token"))
+				.securityMatcher(new AntPathRequestMatcher("/token"))
 				.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
By running the project I found this error .
### 'requestMatcher' has private access in 'org.springframework.security.config.annotation.web.builders.HttpSecurity'